### PR TITLE
docs(profile): short who-we-are blurb

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,3 +1,7 @@
 # Millwater Consulting
 
-Private repository.
+An AI consulting and engineering studio based in Auckland, New Zealand.
+
+We build agent-driven products and infrastructure. Most of our work lives in private repositories.
+
+→ [millwater.consulting](https://millwater.consulting)

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,7 +1,11 @@
 # Millwater Consulting
 
-An AI consulting and engineering studio based in Auckland, New Zealand.
+An AI advisory, consulting and engineering firm operating out of offices in New Zealand, Australia and The United States.
 
-We build agent-driven products and infrastructure. Most of our work lives in private repositories.
+We consult on AI strategy, capability, infrastructure as well build innovative agent-driven products and services.
 
-→ [millwater.consulting](https://millwater.consulting)
+For VC/PE and Technology founders needing  buyside/sell side and exit prep due diligence services please see https://firstlight.millwater.consulting.
+
+For general information on our services see https://millwater.consulting or for  more information reach out to info@millwater.consulting
+
+→ millwater.consulting


### PR DESCRIPTION
Replaces the org-profile placeholder (currently just `Private repository.`) with a brief identity statement.

→ `millwater.consulting` link, location, one-liner on what we build. Three lines total.

No agent-roster, no internal-build detail, no commercial info. Atlas + product repos stay private.