### PR TITLE
feat: org-level default PR + issue templates (org review #15)

### DIFF
--- a/ISSUE_TEMPLATE/task.md
+++ b/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,17 @@
+---
+name: Task
+about: Work item routed to a persona lane
+labels: ''
+---
+
+## What
+<!-- One paragraph: outcome wanted, not implementation. -->
+
+## Why / context
+<!-- Links, incident refs, parent issue. -->
+
+## Acceptance
+<!-- Verifiable criteria. High-stakes builds route through Build Pipeline v2 (Ricky/PA2). -->
+
+## Lane
+<!-- Add the lane label (pa1, dd1, cs1, leg1, web1, cmo1, pa2, lead) so /check-inbox picks it up. -->

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## Summary
+<!-- What does this PR do? One or two sentences. -->
+
+## Changes
+<!-- Bullet list of what changed and why. -->
+-
+
+## Verification
+<!-- How did you verify this works? "Done" claims route through minority-report. -->
+- [ ] Tests run (output in PR or CI)
+- [ ] Containers rebuilt + verified if Dockerised code changed (merges don't deploy)
+- [ ] Release-notes / changelog updated if the repo keeps one
+
+## Governance
+- [ ] Branch follows convention (`<lane>/<short>` or `feat|fix|chore|docs/`)
+- [ ] No secrets committed (vault per mwc-atlas/standards/secrets-registry.md)
+- [ ] No `Co-Authored-By`; no `--no-verify`
+
+## Notes for reviewer
+<!-- Anything the reviewer should know. -->


### PR DESCRIPTION
Org-wide defaults: repos without their own templates inherit these. PR template carries the done-gate (minority-report), rebuild-after-merge rule, and secrets-registry pointer; issue template routes by lane label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)