### PR TITLE
sec: add CODEOWNERS review gate (#1)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Auto-assigns review on every PR (org security review gate). See mwc-atlas.
+* @rishi-builds-ai


### PR DESCRIPTION
Closes #1. Adds a CODEOWNERS file (`* @rishi-builds-ai`) so every PR auto-assigns a review gate — the security finding was that this repo had no review gate. Branch protection itself is the org ruleset (main-guard.yml was retired org-wide per ADR-0038/rulesets).